### PR TITLE
Remove absolute path to true

### DIFF
--- a/makesite/local-server/dev-server-live-reload-watch.sh
+++ b/makesite/local-server/dev-server-live-reload-watch.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Use 'true' from PATH instead of shell builtin
+enable -n true
+
 . "$PYTCH_REPO_BASE"/pytch-build/venv/bin/activate
 cd "$PYTCH_REPO_BASE"/pytch-tutorials
 
@@ -7,7 +10,7 @@ if [ -z "$PYTCH_IN_PROGRESS_TUTORIAL" ]; then
     echo "PYTCH_IN_PROGRESS_TUTORIAL not set; not watching any tutorial/code"
 
     # Keep this script running, to stop the tmux pane from vanishing:
-    while /bin/true; do
+    while true; do
         sleep 60
     done
 fi


### PR DESCRIPTION
Some systems do not have 'true' in /bin/true; trust PATH to find it.

Some BSD systems, MacOS especially, have it in /usr/bin/true. It makes
sense to use PATH to find it. I've no reason to distrust the shell
built-in true, and we could just use that, but I unset it anyway (with
enable) to use the system binary, just in case.